### PR TITLE
Import crayon and magrittr

### DIFF
--- a/.Rhistory
+++ b/.Rhistory
@@ -1,0 +1,100 @@
+# load file (loading from csv depreciated; just renaming)
+sampling.frame<-as.data.frame(samplingframe,stringsAsFactors = FALSE)
+samplingframe<-tibble(a=100)
+samplingframe<-tibble::tibble(a=100)
+# load file (loading from csv depreciated; just renaming)
+sampling.frame<-as.data.frame(samplingframe,stringsAsFactors = FALSE)
+sampling.frame
+sampling.frame<-sf
+devtools::install(build_vignettes = T)
+knitr::opts_chunk$set(
+collapse = TRUE,
+comment = "#>"
+)
+library(surveyweights)
+# example data:
+mydata<-data.frame(somevar1=c(1:5),
+somevar2=c("one","more","test","variable",NA),
+strata_names=c("a","a","b","b","a"),
+cluster_names=c("x","y","z","z","y"))
+# example sampling frame:
+mysf<-data.frame(strata=c("a","b"),pops=c(100,1000))
+clustersf<-data.frame(strata=c("x","y","z"),pops=c(50,100,200))
+mydata
+mysf
+myweighting<-weighting_fun_from_samplingframe(sampling.frame = mysf,
+data.stratum.column = "strata_names",
+sampling.frame.population.column = "pops",
+sampling.frame.stratum.column = "strata")
+devtools::install(dependencies = F,build_vignettes = T)
+print.tibble
+devtools::install_github('sharonorengo/visualisationIMPACT')
+devtools::install_github('sharonorengo/visualisationIMPACT', build_opts = c())
+?dput
+dput(c(1,2,3))
+x<-c(1,2,3)
+dput(x)
+dput(x) %>% class
+dput(names(data.frame(a=10,b=20)))
+y %>% dplyr::select(starts_with("cooking_fuel.")) %>% select_if(is.numeric) %>%  colnames() %>% dput()
+TRUE==1
+list(sf4)
+average_or_percent<-function(survey, indicator_of_interest, by, na.action){
+x<-survey
+ioi<-indicator_of_interest
+ioi_v<-x$variables[,ioi]
+#CREATE FORMULA FOR INDICATOR
+ioi_f<-paste0("~",ioi)
+#IF TRUE REPLACE NAS WITH SOMETHING
+if (z==TRUE){
+x2<-x
+x2$variables[,ioi]<-ifelse(is.na(ioi_v), "not_applicable", as.character(x2$variables[,ioi]))
+x2$variables[,ioi]<-factor(x2$variables[,ioi])
+x2<-x2
+}
+#IF FALSE LEAVE NAS
+if(z==FALSE){
+x2<-x
+}
+#DO ANALYSES WITH SURVEY PACKAGE FUNCTIONALITY
+summary_statistic <- svymean(formula(ioi_f), x2,na.rm=TRUE, na.rm.by = FALSE, keep.var=FALSE )
+summary_statistic
+}
+average_or_percent<-function(survey, indicator_of_interest, by, na.action){
+x<-survey
+ioi<-indicator_of_interest
+ioi_v<-x$variables[,ioi]
+bvar_fa<-paste0(bv1,collapse="+")
+bvar_f<-paste("~",bvar_fa,collapse="")
+#CREATE FORMULA FOR INDICATOR
+ioi_f<-paste0("~",ioi)
+#IF TRUE REPLACE NAS WITH SOMETHING
+if (z==TRUE){
+x2<-x
+x2$variables[,ioi]<-ifelse(is.na(ioi_v), "not_applicable", as.character(x2$variables[,ioi]))
+x2$variables[,ioi]<-factor(x2$variables[,ioi])
+x2<-x2
+}
+#IF FALSE LEAVE NAS
+if(z==FALSE){
+x2<-x
+}
+#DO ANALYSES WITH SURVEY PACKAGE FUNCTIONALITY
+summary_statistic <- svyby(formula(ioi_f),by = formula(bvar_f),FUN = svymean,na.rm = TRUE, na.rm.by = FALSE,design = x2, keep.var=FALSE) %>% data.frame()
+summary_statistic
+}
+class(survey)
+library(assertthat)
+assert_that(is.character(9))
+x<-94558
+assert_that(is.character(x))
+indicator_of_interest<-c("A","B")
+indicator_of_interest
+assert_that(is.string(indicator_of_interest))
+assert_that(is.string(indicator_of_interest))
+testdf<-data.frame(a = c(1:10),b= c(rep("A",5),rep("B",5)))
+many_point_estimates
+testdf<-data.frame(a = c(1:10),b= c(rep("A",5),rep("B",5)))
+testdf
+devtools::use_test()
+browseVignettes('hypegrammaR')

--- a/.Rhistory
+++ b/.Rhistory
@@ -1,0 +1,7 @@
+# load file (loading from csv depreciated; just renaming)
+sampling.frame<-as.data.frame(samplingframe,stringsAsFactors = FALSE)
+samplingframe<-tibble(a=100)
+samplingframe<-tibble::tibble(a=100)
+# load file (loading from csv depreciated; just renaming)
+sampling.frame<-as.data.frame(samplingframe,stringsAsFactors = FALSE)
+sampling.frame

--- a/.Rhistory
+++ b/.Rhistory
@@ -5,3 +5,96 @@ samplingframe<-tibble::tibble(a=100)
 # load file (loading from csv depreciated; just renaming)
 sampling.frame<-as.data.frame(samplingframe,stringsAsFactors = FALSE)
 sampling.frame
+sampling.frame<-sf
+devtools::install(build_vignettes = T)
+knitr::opts_chunk$set(
+collapse = TRUE,
+comment = "#>"
+)
+library(surveyweights)
+# example data:
+mydata<-data.frame(somevar1=c(1:5),
+somevar2=c("one","more","test","variable",NA),
+strata_names=c("a","a","b","b","a"),
+cluster_names=c("x","y","z","z","y"))
+# example sampling frame:
+mysf<-data.frame(strata=c("a","b"),pops=c(100,1000))
+clustersf<-data.frame(strata=c("x","y","z"),pops=c(50,100,200))
+mydata
+mysf
+myweighting<-weighting_fun_from_samplingframe(sampling.frame = mysf,
+data.stratum.column = "strata_names",
+sampling.frame.population.column = "pops",
+sampling.frame.stratum.column = "strata")
+devtools::install(dependencies = F,build_vignettes = T)
+print.tibble
+devtools::install_github('sharonorengo/visualisationIMPACT')
+devtools::install_github('sharonorengo/visualisationIMPACT', build_opts = c())
+?dput
+dput(c(1,2,3))
+x<-c(1,2,3)
+dput(x)
+dput(x) %>% class
+dput(names(data.frame(a=10,b=20)))
+y %>% dplyr::select(starts_with("cooking_fuel.")) %>% select_if(is.numeric) %>%  colnames() %>% dput()
+TRUE==1
+list(sf4)
+average_or_percent<-function(survey, indicator_of_interest, by, na.action){
+x<-survey
+ioi<-indicator_of_interest
+ioi_v<-x$variables[,ioi]
+#CREATE FORMULA FOR INDICATOR
+ioi_f<-paste0("~",ioi)
+#IF TRUE REPLACE NAS WITH SOMETHING
+if (z==TRUE){
+x2<-x
+x2$variables[,ioi]<-ifelse(is.na(ioi_v), "not_applicable", as.character(x2$variables[,ioi]))
+x2$variables[,ioi]<-factor(x2$variables[,ioi])
+x2<-x2
+}
+#IF FALSE LEAVE NAS
+if(z==FALSE){
+x2<-x
+}
+#DO ANALYSES WITH SURVEY PACKAGE FUNCTIONALITY
+summary_statistic <- svymean(formula(ioi_f), x2,na.rm=TRUE, na.rm.by = FALSE, keep.var=FALSE )
+summary_statistic
+}
+average_or_percent<-function(survey, indicator_of_interest, by, na.action){
+x<-survey
+ioi<-indicator_of_interest
+ioi_v<-x$variables[,ioi]
+bvar_fa<-paste0(bv1,collapse="+")
+bvar_f<-paste("~",bvar_fa,collapse="")
+#CREATE FORMULA FOR INDICATOR
+ioi_f<-paste0("~",ioi)
+#IF TRUE REPLACE NAS WITH SOMETHING
+if (z==TRUE){
+x2<-x
+x2$variables[,ioi]<-ifelse(is.na(ioi_v), "not_applicable", as.character(x2$variables[,ioi]))
+x2$variables[,ioi]<-factor(x2$variables[,ioi])
+x2<-x2
+}
+#IF FALSE LEAVE NAS
+if(z==FALSE){
+x2<-x
+}
+#DO ANALYSES WITH SURVEY PACKAGE FUNCTIONALITY
+summary_statistic <- svyby(formula(ioi_f),by = formula(bvar_f),FUN = svymean,na.rm = TRUE, na.rm.by = FALSE,design = x2, keep.var=FALSE) %>% data.frame()
+summary_statistic
+}
+class(survey)
+library(assertthat)
+assert_that(is.character(9))
+x<-94558
+assert_that(is.character(x))
+indicator_of_interest<-c("A","B")
+indicator_of_interest
+assert_that(is.string(indicator_of_interest))
+assert_that(is.string(indicator_of_interest))
+testdf<-data.frame(a = c(1:10),b= c(rep("A",5),rep("B",5)))
+many_point_estimates
+testdf<-data.frame(a = c(1:10),b= c(rep("A",5),rep("B",5)))
+testdf
+devtools::use_test()
+browseVignettes('hypegrammaR')

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: surveyweights
 Type: Package
 Title: Calculate weights from sampling frames
-Version: 0.1.0
+Version: 0.2.0
 Author: Martin Barner
 Maintainer: Martin Barner <martin.barner@impact-initiatives.org>
 Description: Calculate survey weights from sampling frames and data "on the fly", and allows you to combine weights of multiple sampling frames.
@@ -15,5 +15,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 Suggests: 
     knitr,
-    rmarkdown
+    rmarkdown,
+    testthat
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,12 +8,11 @@ Description: Calculate survey weights from sampling frames and data "on the fly"
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-Depends: 
-    magrittr
 Imports:
-    crayon
+    crayon,
+    magrittr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 Suggests: 
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: surveyweights
 Type: Package
 Title: Calculate weights from sampling frames
-Version: 0.1.0
+Version: 0.2.0
 Author: Martin Barner
 Maintainer: Martin Barner <martin.barner@impact-initiatives.org>
 Description: Calculate survey weights from sampling frames and data "on the fly", and allows you to combine weights of multiple sampling frames.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Depends: 
-    magrittr,
+    magrittr
+Imports:
     crayon
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,5 +14,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1
 Suggests: 
     knitr,
-    rmarkdown
+    rmarkdown,
+    testthat
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Depends: 
-    magrittr
+    magrittr,
+    crayon
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1
 Suggests: 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,3 +2,4 @@
 
 export(combine_weighting_functions)
 export(weighting_fun_from_samplingframe)
+importFrom(magrittr,"%>%")

--- a/R/calculate_weights.R
+++ b/R/calculate_weights.R
@@ -29,9 +29,9 @@ stratify.count.sample<-function(data.strata,sf.strata){
   # throw error if data strata not found in sampling frame
 
   if(length(data.strata.not.in.sampleframe)!=0){
-    stop(paste0("problem with ", cat(bgYellow(red(" sampling frame "))),
+    stop(paste0("problem with ", cat(crayon::bgYellow(crayon::red(" sampling frame "))),
                 "in the data, we find the following strata names that don't exist in the sampling frame, or have no valid population numbers:\n",
-                cyan(paste0(names(data.strata.not.in.sampleframe),collapse="\n")))
+                crayon::cyan(paste0(names(data.strata.not.in.sampleframe),collapse="\n")))
     )
   }
   # return sample counts

--- a/R/combine_weighting_functions.R
+++ b/R/combine_weighting_functions.R
@@ -1,13 +1,13 @@
 #' Combine weight functions from two sampling frames
 #'
 #' With multi-stage sampling, it is sometimes necessary to combine the weights from two sampling frames (e.g. stratified cluster sampling).
-#' This function let's you create a new weight function from two existing weight functions created with weighting_fun_from_samplingframe.R}.
+#' This function let's you create a new weight function from two existing weight functions created with weighting_fun_from_samplingframe().
 #' @param weights_function_1 The weight function from the _outer_ sampling frame (the 'larger' scale; Records in one group of the _outer_ sampling frame can belong to different strata in the _inner_ sampling frame.)
 #' @param weights_function_2 The weight function from the _inner_ sampling frame (the 'smaller' scale; Records in the same group of the _inner_ sampling frame must also belong to the same group in the _outer_ sampling frame.)
 #' @details The returned function combines two sets of weights so that
 #' - the sum of weights of each sampling frame's groups remain proportional to each other
 #' - the total sum of weights equals the number of rows in the input data frame
-#' @value returns a function that takes a dataframe as input and returns a vector of weights
+#' @return returns a function that takes a dataframe as input and returns a vector of weights
 #' @export
 combine_weighting_functions<-function(weights_function_1,weights_function_2){
   if(!is.function(weights_function_1)){stop("first input must be a function (see ?load_samplingframe)")}

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -6,7 +6,7 @@
 #' @param data.stratum.column data column name that holds the record's strata names
 #' @param data optional but recommended: you can provide an example data frame of data supposed to match the sampling frame to check if the provided variable names match and whether all strata in the data appear in the sampling frame.
 #' @return returns a new function that takes a data frame as input returns a vector of weights corresponding to each row in the data frame.
-#' @example
+#' @examples
 #' # laod data and sampling frames:
 #' mydata<-read.csv("mydata.csv")
 #' mysamplingframe<-read.csv("mysamplingframe.csv")
@@ -21,6 +21,9 @@
 #' # this also works on subsets of the data:
 #' mydata_subset<-mydata[1:100,]
 #' subset_weights<- weighting(mydata)
+#'
+#' @importFrom magrittr %>%
+#'
 #' @export
 weighting_fun_from_samplingframe <- function(sampling.frame,
                                              data.stratum.column,

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -6,7 +6,7 @@
 #' @param data.stratum.column data column name that holds the record's strata names
 #' @param data optional but recommended: you can provide an example data frame of data supposed to match the sampling frame to check if the provided variable names match and whether all strata in the data appear in the sampling frame.
 #' @return returns a new function that takes a data frame as input returns a vector of weights corresponding to each row in the data frame.
-#' @example
+#' @examples
 #' # laod data and sampling frames:
 #' mydata<-read.csv("mydata.csv")
 #' mysamplingframe<-read.csv("mysamplingframe.csv")

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -79,6 +79,13 @@ weighting_fun_from_samplingframe <- function(sampling.frame,
   # closure function that calculates weights on the fly
   # uses immutable data provided to load_samplingframe()
   weights_of<- function(df) {
+
+    if(!is.data.frame(df)){stop("df must be a data.frame")}
+
+    # in case of tibble.. just to be sure (as tibbles weren't originally accounted for)
+    df<-as.data.frame(df,stringsAsFactors = FALSE)
+    # factors scare me:
+    df<-lapply(df,function(x){if(is.factor(x)){return(as.character(x))};x}) %>% as.data.frame(stringsAsFactors=FALSE)
     # # insure stratum column exists in df:
     if (!all(data.stratum.column %in% names(df))){stop(paste0("data frame column '",data.stratum.column, "'not found."))}
 

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -67,7 +67,7 @@ weighting_fun_from_samplingframe <- function(sampling.frame,
     is_data_in_sf<-unique(data[,data.stratum.column]) %in% sf_raw[,sampling.frame.stratum.column]
     if(any(!(is_data_in_sf))){
       warning(paste0("there are records that can not be found in the sampling frame:\n",
-                     cyan(paste0(data[is_data_in_sf,data.stratum.column] %>% unique,collapse="\n"))))
+                     crayon::cyan(paste0(data[is_data_in_sf,data.stratum.column] %>% unique,collapse="\n"))))
     }
   }
 

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -35,6 +35,9 @@ weighting_fun_from_samplingframe <- function(sampling.frame,
 
   # load file (loading from csv depreciated; just renaming)
   sampling.frame<-as.data.frame(sampling.frame,stringsAsFactors = FALSE)
+  if(!is.null(data)){
+    data<-as.data.frame(data,stringsAsFactors = FALSE)
+  }
   sf_raw<-sampling.frame
   if(any(duplicated(sf_raw[, sampling.frame.stratum.column]))){
     sf_raw<-sf_raw[!duplicated(sf_raw[sampling.frame.stratum.column]),]

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -7,7 +7,7 @@
 #' @param data optional but recommended: you can provide an example data frame of data supposed to match the sampling frame to check if the provided variable names match and whether all strata in the data appear in the sampling frame.
 #' @return returns a new function that takes a data frame as input returns a vector of weights corresponding to each row in the data frame.
 #' @examples
-#' # laod data and sampling frames:
+#' # load data and sampling frames:
 #' mydata<-read.csv("mydata.csv")
 #' mysamplingframe<-read.csv("mysamplingframe.csv")
 #' # create weighting function:
@@ -34,6 +34,7 @@ weighting_fun_from_samplingframe <- function(sampling.frame,
   # check input
 
   # load file (loading from csv depreciated; just renaming)
+  sampling.frame<-as.data.frame(samplingframe,stringsAsFactors = FALSE)
   sf_raw<-sampling.frame
   if(any(duplicated(sf_raw[, sampling.frame.stratum.column]))){
     sf_raw<-sf_raw[!duplicated(sf_raw[sampling.frame.stratum.column]),]

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -34,7 +34,7 @@ weighting_fun_from_samplingframe <- function(sampling.frame,
   # check input
 
   # load file (loading from csv depreciated; just renaming)
-  sampling.frame<-as.data.frame(samplingframe,stringsAsFactors = FALSE)
+  sampling.frame<-as.data.frame(sampling.frame,stringsAsFactors = FALSE)
   sf_raw<-sampling.frame
   if(any(duplicated(sf_raw[, sampling.frame.stratum.column]))){
     sf_raw<-sf_raw[!duplicated(sf_raw[sampling.frame.stratum.column]),]

--- a/R/weighting_fun_from_samplingframe.R
+++ b/R/weighting_fun_from_samplingframe.R
@@ -7,7 +7,8 @@
 #' @param data optional but recommended: you can provide an example data frame of data supposed to match the sampling frame to check if the provided variable names match and whether all strata in the data appear in the sampling frame.
 #' @return returns a new function that takes a data frame as input returns a vector of weights corresponding to each row in the data frame.
 #' @examples
-#' # laod data and sampling frames:
+
+#' # load data and sampling frames:
 #' mydata<-read.csv("mydata.csv")
 #' mysamplingframe<-read.csv("mysamplingframe.csv")
 #' # create weighting function:
@@ -37,6 +38,10 @@ weighting_fun_from_samplingframe <- function(sampling.frame,
   # check input
 
   # load file (loading from csv depreciated; just renaming)
+  sampling.frame<-as.data.frame(sampling.frame,stringsAsFactors = FALSE)
+  if(!is.null(data)){
+    data<-as.data.frame(data,stringsAsFactors = FALSE)
+  }
   sf_raw<-sampling.frame
   if(any(duplicated(sf_raw[, sampling.frame.stratum.column]))){
     sf_raw<-sf_raw[!duplicated(sf_raw[sampling.frame.stratum.column]),]
@@ -78,6 +83,13 @@ weighting_fun_from_samplingframe <- function(sampling.frame,
   # closure function that calculates weights on the fly
   # uses immutable data provided to load_samplingframe()
   weights_of<- function(df) {
+
+    if(!is.data.frame(df)){stop("df must be a data.frame")}
+
+    # in case of tibble.. just to be sure (as tibbles weren't originally accounted for)
+    df<-as.data.frame(df,stringsAsFactors = FALSE)
+    # factors scare me:
+    df<-lapply(df,function(x){if(is.factor(x)){return(as.character(x))};x}) %>% as.data.frame(stringsAsFactors=FALSE)
     # # insure stratum column exists in df:
     if (!all(data.stratum.column %in% names(df))){stop(paste0("data frame column '",data.stratum.column, "'not found."))}
 

--- a/man/combine_weighting_functions.Rd
+++ b/man/combine_weighting_functions.Rd
@@ -11,9 +11,13 @@ combine_weighting_functions(weights_function_1, weights_function_2)
 
 \item{weights_function_2}{The weight function from the \emph{inner} sampling frame (the 'smaller' scale; Records in the same group of the \emph{inner} sampling frame must also belong to the same group in the \emph{outer} sampling frame.)}
 }
+\value{
+returns a function that takes a dataframe as input and returns a vector of weights
+}
 \description{
 With multi-stage sampling, it is sometimes necessary to combine the weights from two sampling frames (e.g. stratified cluster sampling).
-This function let's you create a new weight function from two existing weight functions created with load_samplingframe}
+This function let's you create a new weight function from two existing weight functions created with weighting_fun_from_samplingframe().
+}
 \details{
 The returned function combines two sets of weights so that
 \itemize{

--- a/man/combine_weighting_functions.Rd
+++ b/man/combine_weighting_functions.Rd
@@ -11,8 +11,12 @@ combine_weighting_functions(weights_function_1, weights_function_2)
 
 \item{weights_function_2}{The weight function from the \emph{inner} sampling frame (the 'smaller' scale; Records in the same group of the \emph{inner} sampling frame must also belong to the same group in the \emph{outer} sampling frame.)}
 }
+\value{
+returns a function that takes a dataframe as input and returns a vector of weights
+}
 \description{
-Combine weight functions from two sampling frames
+With multi-stage sampling, it is sometimes necessary to combine the weights from two sampling frames (e.g. stratified cluster sampling).
+This function let's you create a new weight function from two existing weight functions created with weighting_fun_from_samplingframe().
 }
 \details{
 The returned function combines two sets of weights so that

--- a/man/combine_weighting_functions.Rd
+++ b/man/combine_weighting_functions.Rd
@@ -13,7 +13,7 @@ combine_weighting_functions(weights_function_1, weights_function_2)
 }
 \description{
 With multi-stage sampling, it is sometimes necessary to combine the weights from two sampling frames (e.g. stratified cluster sampling).
-This function let's you create a new weight function from two existing weight functions created with \link{\code{load_samplingframe}}.
+This function let's you create a new weight function from two existing weight functions created with XX.
 }
 \details{
 The returned function combines two sets of weights so that

--- a/man/combine_weighting_functions.Rd
+++ b/man/combine_weighting_functions.Rd
@@ -12,8 +12,8 @@ combine_weighting_functions(weights_function_1, weights_function_2)
 \item{weights_function_2}{The weight function from the \emph{inner} sampling frame (the 'smaller' scale; Records in the same group of the \emph{inner} sampling frame must also belong to the same group in the \emph{outer} sampling frame.)}
 }
 \description{
-With multi-stage sampling, it is sometimes necessary to combine the weights from two sampling frames (e.g. stratified cluster sampling).
-This function let's you create a new weight function from two existing weight functions created with load_samplingframe}
+Combine weight functions from two sampling frames
+}
 \details{
 The returned function combines two sets of weights so that
 \itemize{

--- a/man/combine_weighting_functions.Rd
+++ b/man/combine_weighting_functions.Rd
@@ -13,7 +13,7 @@ combine_weighting_functions(weights_function_1, weights_function_2)
 }
 \description{
 With multi-stage sampling, it is sometimes necessary to combine the weights from two sampling frames (e.g. stratified cluster sampling).
-This function let's you create a new weight function from two existing weight functions created with XX.
+This function lets you create a new weight function from two existing weight functions created with load_samplingframe() function.
 }
 \details{
 The returned function combines two sets of weights so that

--- a/man/combine_weighting_functions.Rd
+++ b/man/combine_weighting_functions.Rd
@@ -13,7 +13,7 @@ combine_weighting_functions(weights_function_1, weights_function_2)
 }
 \description{
 With multi-stage sampling, it is sometimes necessary to combine the weights from two sampling frames (e.g. stratified cluster sampling).
-This function lets you create a new weight function from two existing weight functions created with load_samplingframe() function.
+This function lets you create a new weight function from two existing weight functions created with \code{\link{load_samplingframe()}}.
 }
 \details{
 The returned function combines two sets of weights so that

--- a/man/weighting_fun_from_samplingframe.Rd
+++ b/man/weighting_fun_from_samplingframe.Rd
@@ -25,6 +25,19 @@ returns a new function that takes a data frame as input returns a vector of weig
 \description{
 creates a weighting function from a sampling frame
 }
-\seealso{
-\code{\link{load_data} (not implemented), \link{aggregate_count_weighted}}
+\examples{
+# laod data and sampling frames:
+mydata<-read.csv("mydata.csv")
+mysamplingframe<-read.csv("mysamplingframe.csv")
+# create weighting function:
+weighting<-weighting_fun_from_samplingframe(sampling.frame = mysamplingframe,
+                                 data.stratum.column = "strata_names",
+                                 sampling.frame.population.column = "pop",
+                                 sampling.frame.stratum.column = "strat_name")
+# use weighting function:
+mydata$weights<-weighting(mydata)
+
+# this also works on subsets of the data:
+mydata_subset<-mydata[1:100,]
+subset_weights<- weighting(mydata)
 }

--- a/man/weighting_fun_from_samplingframe.Rd
+++ b/man/weighting_fun_from_samplingframe.Rd
@@ -40,5 +40,4 @@ mydata$weights<-weighting(mydata)
 # this also works on subsets of the data:
 mydata_subset<-mydata[1:100,]
 subset_weights<- weighting(mydata)
-
 }

--- a/man/weighting_fun_from_samplingframe.Rd
+++ b/man/weighting_fun_from_samplingframe.Rd
@@ -25,6 +25,20 @@ returns a new function that takes a data frame as input returns a vector of weig
 \description{
 creates a weighting function from a sampling frame
 }
-\seealso{
-\code{\link{load_data} (not implemented), \link{aggregate_count_weighted}}
+\examples{
+# laod data and sampling frames:
+mydata<-read.csv("mydata.csv")
+mysamplingframe<-read.csv("mysamplingframe.csv")
+# create weighting function:
+weighting<-weighting_fun_from_samplingframe(sampling.frame = mysamplingframe,
+                                 data.stratum.column = "strata_names",
+                                 sampling.frame.population.column = "pop",
+                                 sampling.frame.stratum.column = "strat_name")
+# use weighting function:
+mydata$weights<-weighting(mydata)
+
+# this also works on subsets of the data:
+mydata_subset<-mydata[1:100,]
+subset_weights<- weighting(mydata)
+
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(surveyweights)
+
+test_check("surveyweights")


### PR DESCRIPTION
In a fresh R session without other packages loaded, dependencies for `magrittr` failed
````
surveyweights::weighting_fun_from_samplingframe(sampling.frame = sampling_frame,
                                       data = df,
                                       sampling.frame.population.column ="population",
                                       sampling.frame.stratum.column = "LGA_pcode",
                                       data.stratum.column = "lga")
> Error in data[is_data_in_sf, data.stratum.column] %>% unique : 
> could not find function "%>%"
````
 and for `crayon` didn't exist.
````
surveyweights::weighting_fun_from_samplingframe(sampling.frame = sampling_frame,
                                       data = df,
                                       sampling.frame.population.column ="population",
                                       sampling.frame.stratum.column = "LGA_pcode",
                                       data.stratum.column = "lga")
> Error in cyan(paste0(data[is_data_in_sf, data.stratum.column] %>% unique,  : 
> could not find function "cyan"
````
Explicitly imported functions from both packages in the specific function documentation and updated NAMESPACE and DESCRIPTION. No more errors found on my system.